### PR TITLE
Less logging, betters logging readability

### DIFF
--- a/libSearchSECOCrawler/GithubCrawler.cpp
+++ b/libSearchSECOCrawler/GithubCrawler.cpp
@@ -20,9 +20,7 @@ CrawlData GithubCrawler::crawlRepositories(int start)
 	std::unique_ptr<JSON> json(githubInterface->getRequest("https://api.github.com/repositories?since=" + strStart));
 	CrawlData crawlData = getCrawlData(json, handler, currentId);
 
-	LoggerCrawler::logInfo("100% done, finished crawling one page (" + std::to_string(MAXRESULTS) +
-							   " repositories)",
-						   __FILE__, __LINE__);
+	LoggerCrawler::logInfo("100% done", __FILE__, __LINE__);
 	crawlData.finalProjectId = currentId;
 	delete handler;
 	return crawlData;
@@ -168,7 +166,7 @@ ProjectMetadata GithubCrawler::getProjectMetadata(std::string url)
 	// Construct projectMetadata using the owner and repo and the JSON variable we just found.
 	ProjectMetadata projectMetadata = constructProjectMetadata(json, getOwnerAndRepo(url));
 
-	LoggerCrawler::logInfo("Successfully found all relevant metadata, returning.", __FILE__, __LINE__);
+	LoggerCrawler::logDebug("Successfully found all relevant metadata, returning.", __FILE__, __LINE__);
 	delete json;
 	delete handler;
 	delete githubHandler;

--- a/libSearchSECOCrawler/RunCrawler.cpp
+++ b/libSearchSECOCrawler/RunCrawler.cpp
@@ -55,7 +55,7 @@ CrawlData RunCrawler::crawlRepositories(std::string const &url, int start, std::
 	}
 	default:
 	{
-		LoggerCrawler::logInfo("Returning empty", __FILE__, __LINE__);
+		LoggerCrawler::logWarn("Returning empty", __FILE__, __LINE__);
 		errno = 1;
 		return data;
 	}
@@ -68,12 +68,12 @@ CrawlData RunCrawler::crawlGithub(CrawlData data, int start, std::string usernam
 	{
 		GithubCrawler githubCrawler(username, token);
 		CrawlData foundData = githubCrawler.crawlRepositories(start);
-		LoggerCrawler::logInfo("Returning successful", __FILE__, __LINE__);
+		LoggerCrawler::logDebug("Returning successful", __FILE__, __LINE__);
 		return foundData;
 	}
 	catch (int e)
 	{
-		LoggerCrawler::logInfo("Returning empty", __FILE__, __LINE__);
+		LoggerCrawler::logWarn("Returning empty", __FILE__, __LINE__);
 		errno = e;
 		return data;
 	}
@@ -89,7 +89,7 @@ ProjectMetadata RunCrawler::findMetadata(std::string const &url, std::string use
 		return ProjectMetadata();
 	}
 
-	LoggerCrawler::logInfo("Finding metadata for the repository at \"" + url + "\"", __FILE__, __LINE__);
+	LoggerCrawler::logInfo("Getting metadata", __FILE__, __LINE__);
 
 	switch (makeCrawlableSource(url))
 	{
@@ -117,7 +117,7 @@ ProjectMetadata RunCrawler::findMetadataFromGithub(std::string const &url, std::
 	}
 	catch (int e)
 	{
-		LoggerCrawler::logInfo("Returning empty", __FILE__, __LINE__);
+		LoggerCrawler::logWarn("Returning empty", __FILE__, __LINE__);
 		errno = e;
 		return ProjectMetadata();
 	}


### PR DESCRIPTION
Less is more; I moved some logs to the debug level, and changed some logs that remain at the default log level. The program output should be more readable with this change.

Related: https://github.com/SecureSECO/SearchSECOSpider/pull/5